### PR TITLE
docs(README.md): update download link to OTF font file to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ future ideas.
 
 ## Download
 
-[Download font as OTF](./font/thing-regular-0.0.7.otf) (v0.0.7)
+[Download font as OTF](./font/thing-regular-0.0.8.otf) (v0.0.8)
 
 Big shouts to the [opentype.js](https://opentype.js.org/) &
 [FontForge](https://fontforge.org/) teams for simplifying OTF file


### PR DESCRIPTION
### Expected Result:
README.md provides link to download .otf file for current version [v0.0.8](https://github.com/thi-ng/font/blob/master/font/thing-regular-0.0.8.otf)

### Actual Result:
README.md provides link to download .otf file for previous version [v0.0.7](https://github.com/thi-ng/font/blob/master/font/thing-regular-0.0.7.otf)
<img width="483" height="135" alt="image" src="https://github.com/user-attachments/assets/371b6bdb-b89a-4a99-802e-d06e152ac7d9" />


>[!NOTE]
>Since this isn't under the proverbial umbrella and there is no tpl.readme I figured it was okay to
>submit this pull request changing the README.md directly.